### PR TITLE
Transparent menu dropdown

### DIFF
--- a/themes/netflix-red-color-theme.json
+++ b/themes/netflix-red-color-theme.json
@@ -46,7 +46,7 @@
 		"statusBar.debuggingBackground": "#dbbc08",
 		"menu.selectionBackground": "#b9090c59",
 		"menu.separatorBackground": "#000000a4",
-		"menu.background":"#181717fd",
+		"menu.background":"#000000fd",
 		// "menu.background":"#181717a9"
 		"activityBar.background":"#000000",
 		"activityBar.foreground": "#b9090b",


### PR DESCRIPTION
Use Glassit-VSC to make VSCode transparent. `Ctrl + alt + z` to increase alpha and `Ctrl + alt + c` to decrease